### PR TITLE
Fetch the latest Anthropic models

### DIFF
--- a/functions/pipes/anthropic/README.md
+++ b/functions/pipes/anthropic/README.md
@@ -6,7 +6,7 @@ A simple Python interface to interact with Anthropic language models via the Ope
 
 ## Features
 
-- Supports multiple Anthropic models.
+- Supports all available Anthropic models (fetched via API and cached).
 - Handles text and image inputs (with size validation).
 - Supports streaming and non-streaming responses.
 - Easy to configure with your Anthropic API key.
@@ -31,3 +31,4 @@ MIT License
 
 - justinh-rahb ([GitHub](https://github.com/justinh-rahb))
 - christian-taillon
+- jfbloom22 ([GitHub](https://github.com/jfbloom22))

--- a/functions/pipes/anthropic/README.md
+++ b/functions/pipes/anthropic/README.md
@@ -18,6 +18,7 @@ A simple Python interface to interact with Anthropic language models via the Ope
 - Images must be under 5MB each and total under 100MB for a request.
 - The model name should be prefixed with `"anthropic."` (e.g., `"anthropic.claude-3-opus-20240229"`).
 - Errors during requests are returned as strings.
+- The list of models is cached for 10 minutes by default.  This can be changed by setting the `ANTHROPIC_MODEL_CACHE_TTL` environment variable.
 
 ---
 

--- a/functions/pipes/anthropic/main.py
+++ b/functions/pipes/anthropic/main.py
@@ -20,26 +20,20 @@ from open_webui.utils.misc import pop_system_message
 class Pipe:
     class Valves(BaseModel):
         ANTHROPIC_API_KEY: str = Field(default="")
-        MODEL_CACHE_TTL: int = Field(
-            default=int(os.getenv("ANTHROPIC_MODEL_CACHE_TTL", "600")),
-            description="Time in seconds to cache the model list before refreshing",
-        )
 
     def __init__(self):
         self.type = "manifold"
         self.id = "anthropic"
         self.name = "anthropic/"
         self.valves = self.Valves(
-            **{
-                "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", ""),
-                "MODEL_CACHE_TTL": int(os.getenv("ANTHROPIC_MODEL_CACHE_TTL", "600")),
-            }
+            **{"ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", "")}
         )
         self.MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB per image
         
         # Model cache
         self._model_cache: Optional[List[Dict[str, str]]] = None
         self._model_cache_time: float = 0
+        self._cache_ttl = int(os.getenv("ANTHROPIC_MODEL_CACHE_TTL", "600"))
 
     def get_anthropic_models_from_api(self, force_refresh: bool = False) -> List[Dict[str, str]]:
         """
@@ -57,7 +51,7 @@ class Pipe:
         if (
             not force_refresh
             and self._model_cache is not None
-            and (current_time - self._model_cache_time) < self.valves.MODEL_CACHE_TTL
+            and (current_time - self._model_cache_time) < self._cache_ttl
         ):
             return self._model_cache
 

--- a/functions/pipes/anthropic/main.py
+++ b/functions/pipes/anthropic/main.py
@@ -1,9 +1,9 @@
 """
 title: Anthropic Manifold Pipe
-authors: justinh-rahb and christian-taillon
+authors: justinh-rahb, christian-taillon, jfbloom22
 author_url: https://github.com/justinh-rahb
 funding_url: https://github.com/open-webui
-version: 0.2.5
+version: 0.3.0
 required_open_webui_version: 0.3.17
 license: MIT
 """
@@ -12,7 +12,7 @@ import os
 import requests
 import json
 import time
-from typing import List, Union, Generator, Iterator
+from typing import List, Union, Generator, Iterator, Optional, Dict
 from pydantic import BaseModel, Field
 from open_webui.utils.misc import pop_system_message
 
@@ -20,34 +20,97 @@ from open_webui.utils.misc import pop_system_message
 class Pipe:
     class Valves(BaseModel):
         ANTHROPIC_API_KEY: str = Field(default="")
+        MODEL_CACHE_TTL: int = Field(
+            default=int(os.getenv("ANTHROPIC_MODEL_CACHE_TTL", "600")),
+            description="Time in seconds to cache the model list before refreshing",
+        )
 
     def __init__(self):
         self.type = "manifold"
         self.id = "anthropic"
         self.name = "anthropic/"
         self.valves = self.Valves(
-            **{"ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", "")}
+            **{
+                "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", ""),
+                "MODEL_CACHE_TTL": int(os.getenv("ANTHROPIC_MODEL_CACHE_TTL", "600")),
+            }
         )
         self.MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB per image
-        pass
+        
+        # Model cache
+        self._model_cache: Optional[List[Dict[str, str]]] = None
+        self._model_cache_time: float = 0
 
-    def get_anthropic_models(self):
-        return [
-            {"id": "claude-3-haiku-20240307", "name": "claude-3-haiku"},
-            {"id": "claude-3-opus-20240229", "name": "claude-3-opus"},
-            {"id": "claude-3-sonnet-20240229", "name": "claude-3-sonnet"},
-            {"id": "claude-3-5-haiku-20241022", "name": "claude-3.5-haiku"},
-            {"id": "claude-3-5-haiku-latest", "name": "claude-3.5-haiku"},
-            {"id": "claude-3-5-sonnet-20240620", "name": "claude-3.5-sonnet"},
-            {"id": "claude-3-5-sonnet-20241022", "name": "claude-3.5-sonnet"},
-            {"id": "claude-3-5-sonnet-latest", "name": "claude-3.5-sonnet"},
-            {"id": "claude-3-7-sonnet-20250219", "name": "claude-3.7-sonnet"},
-            {"id": "claude-3-7-sonnet-latest", "name": "claude-3.7-sonnet"},
-            {"id": "claude-opus-4-20250514", "name": "claude-opus-4"},
-            {"id": "claude-opus-4-latest", "name": "claude-opus-4"},
-            {"id": "claude-sonnet-4-20250514", "name": "claude-sonnet-4"},
-            {"id": "claude-sonnet-4-latest", "name": "claude-sonnet-4"},
-        ]
+    def get_anthropic_models_from_api(self, force_refresh: bool = False) -> List[Dict[str, str]]:
+        """
+        Retrieve available Anthropic models from the API.
+        Uses caching to reduce API calls.
+
+        Args:
+            force_refresh: Whether to force refreshing the model cache
+
+        Returns:
+            List of dictionaries containing model id and name.
+        """
+        # Check cache first
+        current_time = time.time()
+        if (
+            not force_refresh
+            and self._model_cache is not None
+            and (current_time - self._model_cache_time) < self.valves.MODEL_CACHE_TTL
+        ):
+            return self._model_cache
+
+        if not self.valves.ANTHROPIC_API_KEY:
+            return [
+                {
+                    "id": "error",
+                    "name": "ANTHROPIC_API_KEY is not set. Please update the API Key in the valves.",
+                }
+            ]
+
+        try:
+            headers = {
+                "x-api-key": self.valves.ANTHROPIC_API_KEY,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            }
+            
+            response = requests.get(
+                "https://api.anthropic.com/v1/models",
+                headers=headers,
+                timeout=10
+            )
+            
+            if response.status_code != 200:
+                raise Exception(f"HTTP Error {response.status_code}: {response.text}")
+            
+            data = response.json()
+            models = []
+            
+            for model in data.get("data", []):
+                models.append({
+                    "id": model["id"],
+                    "name": model.get("display_name", model["id"]),
+                })
+            
+            # Update cache
+            self._model_cache = models
+            self._model_cache_time = current_time
+            
+            return models
+            
+        except Exception as e:
+            print(f"Error fetching Anthropic models: {e}")
+            return [
+                {"id": "error", "name": f"Could not fetch models from Anthropic: {str(e)}"}
+            ]
+
+    def get_anthropic_models(self) -> List[Dict[str, str]]:
+        """
+        Get Anthropic models from the API.
+        """
+        return self.get_anthropic_models_from_api()
 
     def pipes(self) -> List[dict]:
         return self.get_anthropic_models()


### PR DESCRIPTION
Anthropic models will become available as soon as they are available in the model list API endpoint.
Defaults to 10 minute cache so that we don't introduce excessive API calls getting the model list.  