### PR TITLE
check for images in all messages of the chat - not only the last one

### DIFF
--- a/functions/filters/dynamic_vision_router/main.py
+++ b/functions/filters/dynamic_vision_router/main.py
@@ -4,7 +4,7 @@ author: open-webui, atgehrhardt,
     credits to @iamg30 for v0.1.5-v0.1.7 updates
 author_url: https://github.com/open-webui
 funding_url: https://github.com/open-webui
-version: 0.1.7
+version: 0.1.8
 required_open_webui_version: 0.3.8
 """
 
@@ -83,6 +83,17 @@ class Filter:
                 has_images = any(
                     item.get("type") == "image_url" for item in user_message_content
                 )
+
+        # check for all history
+        if not has_images:
+            for m in messages:
+                user_message_content = m.get("content")
+                if user_message_content is not None and isinstance(
+                    user_message_content, list
+                ):
+                    has_images = any(
+                        item.get("type") == "image_url" for item in user_message_content
+                    )
 
         if has_images:
             if self.valves.vision_model_id:


### PR DESCRIPTION
It was checking only the last image of the chat, meaning that if the user continued the conversation, it would break because the original model may not accept images/multi-modal inputs.

With this change, it checks the entire history for images before deciding to route - or not - the request, ensuring that follow-up questions are still analyzed by the vison-enabled model.